### PR TITLE
Data save RSS and local source done

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,9 @@ android {
 }
 
 dependencies {
-
+    //GSON
+    implementation 'com.google.code.gson:gson:2.10'
+    //ANDROID DEFAULT IMPLEMENTATIONS
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'com.google.android.material:material:1.7.0'

--- a/app/src/main/java/com/example/app/serializer/KSerializer.kt
+++ b/app/src/main/java/com/example/app/serializer/KSerializer.kt
@@ -1,0 +1,21 @@
+package com.example.app.serializer
+
+import com.google.gson.Gson
+
+interface KSerializer {
+    fun <T> fromJson(json: String?, classObj: Class<T>): T
+    fun <T> toJson(obj: T, classObj: Class<T>): String
+}
+
+class GsonSerializer : KSerializer {
+
+    private val gson = Gson()
+
+    override fun <T> fromJson(json: String?, classObj: Class<T>): T {
+        return gson.fromJson(json, classObj)
+    }
+
+    override fun <T> toJson(obj: T, classObj: Class<T>): String {
+        return gson.toJson(obj, classObj)
+    }
+}

--- a/app/src/main/java/com/example/rssapp/management/data/ManagementDataRepository.kt
+++ b/app/src/main/java/com/example/rssapp/management/data/ManagementDataRepository.kt
@@ -1,0 +1,13 @@
+package com.example.rssapp.management.data
+
+import com.example.rssapp.management.data.xml.XmlLocalDataSource
+import com.example.rssapp.management.domain.Management
+import com.example.rssapp.management.domain.ManagementRepository
+
+class ManagementDataRepository (private val source: XmlLocalDataSource): ManagementRepository{
+
+    override suspend fun saveRss(url: String, name: String) {
+        source.createRss(url, name)
+    }
+
+}

--- a/app/src/main/java/com/example/rssapp/management/data/ManagementLocalSource.kt
+++ b/app/src/main/java/com/example/rssapp/management/data/ManagementLocalSource.kt
@@ -1,0 +1,5 @@
+package com.example.rssapp.management.data
+
+interface ManagementLocalSource {
+    fun createRss(url:String, name:String)
+}

--- a/app/src/main/java/com/example/rssapp/management/data/xml/XmlLocalDataSource.kt
+++ b/app/src/main/java/com/example/rssapp/management/data/xml/XmlLocalDataSource.kt
@@ -1,0 +1,16 @@
+package com.example.rssapp.management.data.xml
+
+import android.content.SharedPreferences
+import com.example.app.serializer.KSerializer
+import com.example.rssapp.management.data.ManagementLocalSource
+import com.example.rssapp.management.domain.Management
+
+class XmlLocalDataSource (private val sharedPreferences: SharedPreferences, private val serializer: KSerializer) : ManagementLocalSource{
+
+    private val editor = sharedPreferences.edit()
+
+    override fun createRss(url: String, name: String) {
+        editor.putString(url, serializer.toJson(Management(name, url), Management::class.java))
+    }
+
+}

--- a/app/src/main/java/com/example/rssapp/management/domain/Management.kt
+++ b/app/src/main/java/com/example/rssapp/management/domain/Management.kt
@@ -1,0 +1,3 @@
+package com.example.rssapp.management.domain
+
+data class Management(val url:String, val name:String)

--- a/app/src/main/java/com/example/rssapp/management/domain/ManagementAddRssUseCase.kt
+++ b/app/src/main/java/com/example/rssapp/management/domain/ManagementAddRssUseCase.kt
@@ -1,7 +1,7 @@
 package com.example.rssapp.management.domain
 
-class ManagementAddRssUseCase(val repository: ManagementRepository) {
-    fun execute(name:String, url:String){
-        repository.saveRss(ManagementModel(name, url))
+class ManagementAddRssUseCase(private val repository: ManagementRepository) {
+    suspend fun execute(url:String, name:String){
+        repository.saveRss(url, name)
     }
 }

--- a/app/src/main/java/com/example/rssapp/management/domain/ManagementModel.kt
+++ b/app/src/main/java/com/example/rssapp/management/domain/ManagementModel.kt
@@ -1,3 +1,0 @@
-package com.example.rssapp.management.domain
-
-data class ManagementModel(val name:String, val url:String)

--- a/app/src/main/java/com/example/rssapp/management/domain/ManagementRepository.kt
+++ b/app/src/main/java/com/example/rssapp/management/domain/ManagementRepository.kt
@@ -1,5 +1,5 @@
 package com.example.rssapp.management.domain
 
 interface ManagementRepository {
-    fun saveRss(model: ManagementModel)
+    suspend fun saveRss(url:String, name:String)
 }


### PR DESCRIPTION
## DESCRIPCION
En esta pull request se documenta la decision de escoger una fuente de datos local al igual que se explica su implementación.

## COMO HA SIDO IMPLEMENTADO
Hemos decidido que cuando el usuario guarde RSS, las guardaremos en un xml, dado que siendo una estructura tan simple (sólo hay dos atributos en la clase), creemos que es mejor almacenarlo ahí.
Hemos realizado las funciones suspend desde el caso de uso para asi vernos obligados a utilizar corrutinas, y que los casos de uso solo se puedan ejecutar desde otras corrutinas.

## AVISO
Hay cambios reflejados en clases que solo era para organizar la forma en la que llamo a los atributos url y name. Se pueden ignorar dichos cambios dado que es una cuestión de organización en el codigo y nada más. Lamento no haber contemplado esto antes.

## PALABRAS CLAVE
Save, Local, DataSource, Repository, Suspend, Corrutinas 