### PR TITLE
Creacion del caso de uso que mostrará el feed de noticias de cada rss

### DIFF
--- a/app/src/main/java/com/example/rssapp/showfeed/data/remote/api/DomainMapper.kt
+++ b/app/src/main/java/com/example/rssapp/showfeed/data/remote/api/DomainMapper.kt
@@ -1,0 +1,8 @@
+package com.example.rssapp.showfeed.data.remote.api
+
+import com.example.rssapp.showfeed.domain.NewsRss
+import com.example.rssapp.showfeed.domain.RssNewsFeedUseCaseModel
+
+fun NewsRss.toDomain(): RssNewsFeedUseCaseModel {
+    return RssNewsFeedUseCaseModel(this.thumbnail, this.title, this.description, this.link, this.pubDate)
+}

--- a/app/src/main/java/com/example/rssapp/showfeed/domain/GetRssNewsFeedUseCase.kt
+++ b/app/src/main/java/com/example/rssapp/showfeed/domain/GetRssNewsFeedUseCase.kt
@@ -1,0 +1,14 @@
+package com.example.rssapp.showfeed.domain
+
+import com.example.rssapp.showfeed.data.remote.api.toDomain
+
+class GetRssNewsFeedUseCase (private val repository: NewsRssRepository){
+    fun invoke(url:String):List<RssNewsFeedUseCaseModel>{
+        val list = repository.getRssNewsFeed(url)
+        return list.map {
+            it.toDomain()
+        }
+    }
+}
+
+data class RssNewsFeedUseCaseModel(val thumbnail: String, val title:String, val description:String, val link:String, val pubDate:String)

--- a/app/src/main/java/com/example/rssapp/showfeed/domain/Models.kt
+++ b/app/src/main/java/com/example/rssapp/showfeed/domain/Models.kt
@@ -1,0 +1,3 @@
+package com.example.rssapp.showfeed.domain
+
+data class NewsRss(val channel:String, val title:String, val description:String, val link:String, val pubDate:String, val creator:String, val content:String, val thumbnail:String)

--- a/app/src/main/java/com/example/rssapp/showfeed/domain/NewsRssRepository.kt
+++ b/app/src/main/java/com/example/rssapp/showfeed/domain/NewsRssRepository.kt
@@ -1,0 +1,5 @@
+package com.example.rssapp.showfeed.domain
+
+interface NewsRssRepository {
+    fun getRssNewsFeed(url:String): List<NewsRss>
+}


### PR DESCRIPTION
## DESCRIPCIÓN
Se ha creado el caso de uso que mostrará el feed de noticias de cada rss a través de su id (en este caso hemos escogido la url de la rss como identificador único)

## COMO HA SIDO IMPLEMENTADO
Lo primero hemos creado un modelo de dominio general que recoge casi todos los datos que podamos querer llegar a mostrar. Tras esto, un repositorio de noticias de rss, definirá los métodos a utilizar para dichas noticias. El caso de uso que devolverá una lista de su propio modelo con los atributos mencionados en el issue. Por último hemos creado un mapper para poder pasar de modelos de dominio a modelos de cada caso de uso particular (en este caso, el get que recogerá el feed)

## KEYWORDS
Domain, Repository, Rss, UseCase, Mapper